### PR TITLE
remove trailing comma in hid report descriptor

### DIFF
--- a/TinyUSB_Mouse_and_Keyboard.cpp
+++ b/TinyUSB_Mouse_and_Keyboard.cpp
@@ -63,8 +63,8 @@
   // Single Report (no ID) descriptor
   uint8_t const desc_hid_report[] =
   {
-	TUD_HID_REPORT_DESC_KEYBOARD( HID_REPORT_ID(RID_KEYBOARD), ),
-    TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(RID_MOUSE),)
+    TUD_HID_REPORT_DESC_KEYBOARD( HID_REPORT_ID(RID_KEYBOARD) ),
+    TUD_HID_REPORT_DESC_MOUSE( HID_REPORT_ID(RID_MOUSE) )
   };
 
   Adafruit_USBD_HID usb_hid;


### PR DESCRIPTION
following the release of BSP SAMD 1.5.12 and NRF 0.9.0 and TinyUSB LIbrary 0.9.0. The trailing comma in hid descriptor is dropped to have an "normal" instead of werid looking descriptor.